### PR TITLE
Fix typo on spanish template

### DIFF
--- a/DefaultEspañol.tb7
+++ b/DefaultEspañol.tb7
@@ -2523,7 +2523,7 @@
       <LongDescription />
     </ThreatCategory>
     <ThreatCategory>
-      <Name>Manipluacion (Tampering)</Name>
+      <Name>Manipulacion (Tampering)</Name>
       <Id>T</Id>
       <ShortDescription>La manipulación es el acto de alterar los bits. La manipulación de un proceso implica cambiar bits en el proceso en ejecución. Del mismo modo, la manipulación de un flujo de datos implica cambiar bits en el cable o entre dos procesos en ejecución.</ShortDescription>
       <LongDescription />


### PR DESCRIPTION
The Spanish template has a typo on one Threat title. It says "Manipluacion" instead of "Manipulacion".